### PR TITLE
[Syntax] Fix LEAF_STMT macro

### DIFF
--- a/clang/lib/Tooling/Syntax/BuildFromAST.cpp
+++ b/clang/lib/Tooling/Syntax/BuildFromAST.cpp
@@ -149,7 +149,7 @@ public:
 // Statements.
 /// Leaf statements consume the trailing semicolon.
 #define LEAF_STMT(ASTStmt, SynStmt)                                            \
-  bool WalkUpFrom##ASTNode(clang::ASTStmt *N) {                                \
+  bool WalkUpFrom##ASTStmt(clang::ASTStmt *N) {                                \
     return WalkUpFromTrivial<syntax::SynStmt, clang::ASTStmt>(N);              \
   }
 /// Composite statements do not have trailing semicolons.


### PR DESCRIPTION
This fixes handling of `return` statements, that were handles as recovery nodes, since the function name was generated wrongly.